### PR TITLE
i-bem: re-entrant BEMContext

### DIFF
--- a/i-bem__html.bemhtml
+++ b/i-bem__html.bemhtml
@@ -186,6 +186,7 @@ function BEMContext(apply_) {
   this._start = true;
   this._listLength = 0;
   this._notNewList = false;
+  this._inside = false;
   this.position = 0;
 };
 
@@ -266,11 +267,23 @@ BEMContext.prototype.generateId = function generateId() {
     return this.identify(this.ctx);
 };
 
+function slowApply() {
+    var ctx = new BEMContext(apply);
+    ctx.reinit(this);
+    ctx.apply();
+    return ctx._buf.join('');
+};
+
 // Wrap xjst's apply and export our own
 var ctx = new BEMContext(apply);
 exports.apply = BEMContext.apply = function _apply() {
+    if (ctx._inside)
+      return slowApply.call(this);
+
+    ctx._inside = true;
     ctx.reinit(this);
     ctx.apply();
+    ctx._inside = false;
     return ctx._buf.join('');
 };
 }();

--- a/test/files/i-bem/re-entrant.bemhtml
+++ b/test/files/i-bem/re-entrant.bemhtml
@@ -1,0 +1,9 @@
+block b1, content: {
+  return this.invalid || 'ok';
+}
+
+block b2, content: {
+  local(this.invalid = 'bye') {
+    throw new Error('Oh god');
+  }
+}

--- a/test/i-bem-test.js
+++ b/test/i-bem-test.js
@@ -47,4 +47,12 @@ suite('i-bem block and others', function() {
   unit('simple types regression #254', 'gh-254');
   unit('applyNext in content regression #289', 'gh-289');
   unit('block with escaping this', 'escaping-this');
+
+  test('re-entrance', function() {
+    var t = bemhtml.compile(iBem + readFile('i-bem/re-entrant.bemhtml'));
+    assert.throws(function() {
+      t.call({ block: 'b2' });
+    });
+    assert.equal(t.call({ block: 'b1' }), '<div class="b1">ok</div>');
+  });
 });


### PR DESCRIPTION
Fall back to slower version of `.apply()` if exception was thrown or the
`BEMHTML.apply()` was re-entered.
